### PR TITLE
Codex support for ccn 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,17 @@ chmod +x ~/.local/bin/claude-notify
 ## Documentation
 
 - [Installation Guide](https://cc-notify.bupd.xyz/#/installation)
+- [Codex Installation](docs/codex-installation.md)
 - [Configuration](https://cc-notify.bupd.xyz/#/configuration)
 - [Keyboard Navigation](https://cc-notify.bupd.xyz/#/keyboard-navigation)
+
+## Codex
+
+Codex support is available via wrapper scripts and watcher-based notifications.
+
+- Use `codex-with-notify` when you want Codex completion notifications.
+- Why wrapper mode: Claude can use built-in hooks, while Codex uses `codex-watch` + `codex-notify`.
+- Setup guide: [docs/codex-installation.md](docs/codex-installation.md)
 
 ## Why Not a Full Orchestration Tool?
 

--- a/docs/codex-installation.md
+++ b/docs/codex-installation.md
@@ -1,0 +1,115 @@
+# Codex Installation
+
+## Prerequisites
+
+Install dependencies:
+
+```bash
+# Arch Linux
+sudo pacman -S dunst tmux jq
+
+# Ubuntu/Debian
+sudo apt install dunst tmux jq
+
+# Fedora
+sudo dnf install dunst tmux jq
+```
+
+Make sure `dunst` is running.
+
+## Install Scripts
+
+```bash
+git clone https://github.com/bupd/ccn.git
+cd ccn
+
+cp scripts/codex-notify ~/.local/bin/
+cp scripts/codex-watch ~/.local/bin/
+cp scripts/codex-with-notify ~/.local/bin/
+chmod +x ~/.local/bin/codex-notify ~/.local/bin/codex-watch ~/.local/bin/codex-with-notify
+```
+
+## Recommended Usage (tmux-aware pane jump)
+
+Run Codex with the wrapper from inside tmux:
+
+```bash
+codex-with-notify
+```
+
+Optional shell alias:
+
+```bash
+alias codexn="$HOME/.local/bin/codex-with-notify"
+```
+
+Now use `codexn` whenever you want notifications.
+
+## Why `codex-with-notify` (and why this differs from Claude)
+
+Claude can call notification commands directly through built-in hooks in `~/.claude/settings.json` (for example, on `Stop`/`Notification` events). That means plain `claude` can trigger notifications without a wrapper.
+
+Codex does not currently expose the same hook flow for this use case, so plain `codex` does not automatically run a notification command when a task completes.
+
+`codex-with-notify` solves this by starting `codex-watch` in the background while Codex runs, then cleaning it up when Codex exits. This gives you Claude-like completion notifications for Codex.
+
+## Optional Always-on Watcher (global alerts)
+
+This mode notifies for Codex completions across sessions, even when you do not use the wrapper.
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp systemd/user/codex-watch.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now codex-watch.service
+```
+
+Check status:
+
+```bash
+systemctl --user status codex-watch.service
+```
+
+Stop/disable:
+
+```bash
+systemctl --user disable --now codex-watch.service
+```
+
+## How Detection Works
+
+`codex-watch` monitors `~/.codex/sessions/**/*.jsonl` and triggers notifications when it sees:
+
+- `type = event_msg`
+- `payload.type = task_complete`
+
+## Verify
+
+1. Start tmux
+2. Run `codex-with-notify`
+3. Let Codex finish a turn and wait for your input
+4. You should see a notification
+5. Click `Go to pane` to jump back
+
+## Troubleshooting
+
+### No notifications
+
+```bash
+pgrep dunst
+```
+
+```bash
+dunstify "Test" "Codex notification test"
+```
+
+### No pane switch on click
+
+- Use `codex-with-notify` inside tmux (recommended)
+- Ensure a tmux client is attached
+
+### Watcher debug mode
+
+```bash
+codex-watch --verbose
+```

--- a/scripts/codex-notify
+++ b/scripts/codex-notify
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -u
+
+usage() {
+    cat <<'USAGE'
+Usage: codex-notify [--title TITLE] [--message MESSAGE] [--tmux-target SESSION:WINDOW.PANE] [--enable-switch]
+
+Options:
+  --title        Notification title (default: Codex Agent)
+  --message      Notification body (default: Needs your attention)
+  --tmux-target  Explicit tmux target to jump to on click
+  --enable-switch  Enable tmux switching action (default: off)
+USAGE
+}
+
+title="Codex Agent"
+message="Needs your attention"
+tmux_target=""
+enable_switch="${CODEX_NOTIFY_ENABLE_SWITCH:-0}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title)
+            title="${2:-}"
+            shift 2
+            ;;
+        --message)
+            message="${2:-}"
+            shift 2
+            ;;
+        --tmux-target)
+            tmux_target="${2:-}"
+            shift 2
+            ;;
+        --enable-switch)
+            enable_switch=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Backward-compatible positional args: codex-notify "title" "message"
+if [[ $# -ge 1 ]]; then
+    title="$1"
+fi
+if [[ $# -ge 2 ]]; then
+    message="$2"
+fi
+
+if ! command -v dunstify >/dev/null 2>&1; then
+    exit 0
+fi
+
+if [[ -z "$tmux_target" && -n "${TMUX:-}" ]] && command -v tmux >/dev/null 2>&1; then
+    tmux_target="$(tmux display-message -p '#S:#I.#P' 2>/dev/null || true)"
+fi
+
+tmux_socket="${TMUX:-}"
+window_name=""
+if [[ -n "${TMUX:-}" ]] && command -v tmux >/dev/null 2>&1; then
+    window_name="$(tmux display-message -p '#S:#W' 2>/dev/null || true)"
+fi
+
+if [[ -n "$window_name" ]]; then
+    notify_title="$title - $window_name"
+else
+    notify_title="$title"
+fi
+
+if [[ "$enable_switch" != "1" ]]; then
+    dunstify "$notify_title" "$message" -t 20000 >/dev/null 2>&1 || true
+    exit 0
+fi
+
+action="$(dunstify \
+    -A "default,Go to pane" \
+    "$notify_title" \
+    "$message" \
+    -t 20000 \
+    -b || true)"
+
+if [[ "$action" == "default" && -n "$tmux_target" ]] && command -v tmux >/dev/null 2>&1; then
+    if [[ -n "$tmux_socket" ]]; then
+        export TMUX="$tmux_socket"
+    fi
+
+    tmux switch-client -t "$tmux_target" >/dev/null 2>&1 || true
+
+    # Best-effort: focus the terminal window that owns this tmux client in Hyprland.
+    if command -v hyprctl >/dev/null 2>&1; then
+        client_pid="$(tmux list-clients -F '#{session_name}:#{window_index}.#{pane_index} #{client_pid}' 2>/dev/null | awk -v t="$tmux_target" '$1==t {print $2; exit}')"
+        if [[ -n "${client_pid:-}" ]]; then
+            focus_pid="$client_pid"
+            for _ in 1 2 3 4 5 6 7 8; do
+                parent_pid="$(ps -p "$focus_pid" -o ppid= 2>/dev/null | tr -d '[:space:]')"
+                if [[ -z "$parent_pid" || "$parent_pid" == "1" ]]; then
+                    break
+                fi
+
+                parent_comm="$(ps -p "$parent_pid" -o comm= 2>/dev/null | awk '{print $1}')"
+                if [[ "$parent_comm" == "Hyprland" ]]; then
+                    break
+                fi
+
+                focus_pid="$parent_pid"
+            done
+
+            hyprctl dispatch focuswindow "pid:$focus_pid" >/dev/null 2>&1 || true
+        fi
+    fi
+fi

--- a/scripts/codex-watch
+++ b/scripts/codex-watch
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -u
+
+usage() {
+    cat <<'USAGE'
+Usage: codex-watch [options]
+
+Options:
+  --sessions-dir DIR       Codex sessions root (default: ~/.codex/sessions)
+  --notify-cmd PATH        codex-notify command path (default: ~/.local/bin/codex-notify)
+  --interval SECONDS       Poll interval (default: 1)
+  --title TITLE            Notification title (default: Codex Agent)
+  --tmux-target TARGET     Force tmux target for notification action
+  --enable-switch          Enable click-to-switch action in notifications
+  --start-at-beginning     Parse existing files from byte 0 (default: start at end)
+  --verbose                Print debug logs
+  -h, --help               Show this help
+
+Trigger condition:
+  Emits a notification when a Codex session line contains
+  type=event_msg and payload.type=task_complete.
+USAGE
+}
+
+sessions_dir="$HOME/.codex/sessions"
+notify_cmd="$HOME/.local/bin/codex-notify"
+interval=1
+title="Codex Agent"
+tmux_target=""
+enable_switch="${CODEX_NOTIFY_ENABLE_SWITCH:-0}"
+start_at_end=1
+verbose=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --sessions-dir)
+            sessions_dir="${2:-}"
+            shift 2
+            ;;
+        --notify-cmd)
+            notify_cmd="${2:-}"
+            shift 2
+            ;;
+        --interval)
+            interval="${2:-1}"
+            shift 2
+            ;;
+        --title)
+            title="${2:-}"
+            shift 2
+            ;;
+        --tmux-target)
+            tmux_target="${2:-}"
+            shift 2
+            ;;
+        --enable-switch)
+            enable_switch=1
+            shift
+            ;;
+        --start-at-beginning)
+            start_at_end=0
+            shift
+            ;;
+        --verbose)
+            verbose=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -d "$sessions_dir" ]]; then
+    echo "Sessions dir not found: $sessions_dir" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required for codex-watch" >&2
+    exit 1
+fi
+
+if [[ ! -x "$notify_cmd" ]]; then
+    echo "Notify command not executable: $notify_cmd" >&2
+    exit 1
+fi
+
+if ! [[ "$interval" =~ ^[0-9]+$ ]] || [[ "$interval" -lt 1 ]]; then
+    echo "--interval must be a positive integer" >&2
+    exit 2
+fi
+
+declare -A OFFSETS=()
+declare -A SEEN=()
+
+log() {
+    if [[ "$verbose" -eq 1 ]]; then
+        printf '[codex-watch] %s\n' "$*" >&2
+    fi
+}
+
+init_file_offset() {
+    local file="$1"
+    local size
+    size="$(stat -c%s "$file" 2>/dev/null || echo 0)"
+    if [[ "$start_at_end" -eq 1 ]]; then
+        OFFSETS["$file"]="$size"
+    else
+        OFFSETS["$file"]=0
+    fi
+}
+
+process_line() {
+    local line="$1"
+    local parsed
+    parsed="$(printf '%s' "$line" | jq -r 'select(.type == "event_msg" and .payload.type == "task_complete") | .payload.turn_id' 2>/dev/null || true)"
+    [[ -z "$parsed" ]] && return 0
+
+    local turn_id="$parsed"
+
+    if [[ -z "$turn_id" ]]; then
+        return 0
+    fi
+
+    if [[ -n "${SEEN[$turn_id]:-}" ]]; then
+        return 0
+    fi
+
+    SEEN["$turn_id"]=1
+
+    local body="Codex needs your input"
+
+    log "task_complete turn_id=$turn_id"
+
+    if [[ -n "$tmux_target" ]]; then
+        if [[ "$enable_switch" == "1" ]]; then
+            "$notify_cmd" --title "$title" --message "$body" --tmux-target "$tmux_target" --enable-switch >/dev/null 2>&1 || true
+        else
+            "$notify_cmd" --title "$title" --message "$body" --tmux-target "$tmux_target" >/dev/null 2>&1 || true
+        fi
+    else
+        if [[ "$enable_switch" == "1" ]]; then
+            "$notify_cmd" --title "$title" --message "$body" --enable-switch >/dev/null 2>&1 || true
+        else
+            "$notify_cmd" --title "$title" --message "$body" >/dev/null 2>&1 || true
+        fi
+    fi
+}
+
+process_file() {
+    local file="$1"
+    local size start chunk
+
+    size="$(stat -c%s "$file" 2>/dev/null || echo 0)"
+    start="${OFFSETS[$file]:-0}"
+
+    if [[ "$size" -lt "$start" ]]; then
+        start=0
+    fi
+
+    if [[ "$size" -le "$start" ]]; then
+        OFFSETS["$file"]="$size"
+        return 0
+    fi
+
+    chunk="$(tail -c +$((start + 1)) "$file" 2>/dev/null || true)"
+    OFFSETS["$file"]="$size"
+
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        process_line "$line"
+    done <<< "$chunk"
+}
+
+while true; do
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        if [[ -z "${OFFSETS[$file]:-}" ]]; then
+            init_file_offset "$file"
+            log "tracking $file from byte ${OFFSETS[$file]}"
+            continue
+        fi
+        process_file "$file"
+    done < <(find "$sessions_dir" -type f -name '*.jsonl' | sort)
+
+    sleep "$interval"
+done

--- a/scripts/codex-watch
+++ b/scripts/codex-watch
@@ -99,11 +99,36 @@ fi
 
 declare -A OFFSETS=()
 declare -A SEEN=()
+seen_root="${XDG_RUNTIME_DIR:-/tmp}/codex-watch-seen"
+cleanup_counter=0
+
+mkdir -p "$seen_root" >/dev/null 2>&1 || true
 
 log() {
     if [[ "$verbose" -eq 1 ]]; then
         printf '[codex-watch] %s\n' "$*" >&2
     fi
+}
+
+claim_turn_id() {
+    local turn_id="$1"
+    local claim_dir="$seen_root/$turn_id"
+
+    if mkdir "$claim_dir" >/dev/null 2>&1; then
+        date +%s > "$claim_dir/ts" 2>/dev/null || true
+        return 0
+    fi
+
+    return 1
+}
+
+cleanup_claims() {
+    cleanup_counter=$((cleanup_counter + 1))
+    if (( cleanup_counter % 120 != 0 )); then
+        return 0
+    fi
+
+    find "$seen_root" -mindepth 1 -maxdepth 1 -type d -mmin +1440 -exec rm -rf {} + >/dev/null 2>&1 || true
 }
 
 init_file_offset() {
@@ -134,6 +159,15 @@ process_line() {
     fi
 
     SEEN["$turn_id"]=1
+
+    # Prefer tmux-scoped watchers when multiple watchers are running.
+    if [[ -z "$tmux_target" ]]; then
+        sleep 0.15
+    fi
+
+    if ! claim_turn_id "$turn_id"; then
+        return 0
+    fi
 
     local body="Codex needs your input"
 
@@ -180,6 +214,8 @@ process_file() {
 }
 
 while true; do
+    cleanup_claims
+
     while IFS= read -r file; do
         [[ -z "$file" ]] && continue
         if [[ -z "${OFFSETS[$file]:-}" ]]; then

--- a/scripts/codex-with-notify
+++ b/scripts/codex-with-notify
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -u
+
+notify_cmd="${CODEX_NOTIFY_CMD:-$HOME/.local/bin/codex-notify}"
+watch_cmd="${CODEX_WATCH_CMD:-$HOME/.local/bin/codex-watch}"
+interval="${CODEX_NOTIFY_INTERVAL:-1}"
+title="${CODEX_NOTIFY_TITLE:-Codex Agent}"
+switch_on_click="${CODEX_NOTIFY_ENABLE_SWITCH:-1}"
+
+if ! command -v codex >/dev/null 2>&1; then
+    echo "codex command not found" >&2
+    exit 127
+fi
+
+if [[ ! -x "$watch_cmd" ]]; then
+    echo "codex watcher not found or not executable: $watch_cmd" >&2
+    exit 1
+fi
+
+if [[ ! -x "$notify_cmd" ]]; then
+    echo "codex notify script not found or not executable: $notify_cmd" >&2
+    exit 1
+fi
+
+tmux_target=""
+if [[ -n "${TMUX:-}" ]] && command -v tmux >/dev/null 2>&1; then
+    tmux_target="$(tmux display-message -p '#S:#I.#P' 2>/dev/null || true)"
+fi
+
+watch_pid=""
+cleanup() {
+    if [[ -n "$watch_pid" ]] && kill -0 "$watch_pid" >/dev/null 2>&1; then
+        kill "$watch_pid" >/dev/null 2>&1 || true
+        wait "$watch_pid" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+watch_args=(--notify-cmd "$notify_cmd" --interval "$interval" --title "$title")
+if [[ -n "$tmux_target" ]]; then
+    watch_args+=(--tmux-target "$tmux_target")
+fi
+if [[ "$switch_on_click" == "1" ]]; then
+    watch_args+=(--enable-switch)
+fi
+
+"$watch_cmd" "${watch_args[@]}" &
+watch_pid="$!"
+
+codex "$@"
+exit_code=$?
+
+cleanup
+exit "$exit_code"

--- a/systemd/user/codex-watch.service
+++ b/systemd/user/codex-watch.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Codex session watcher (desktop notifications)
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/codex-watch
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## This PR adds Codex notification support to CCN while keeping existing Claude behavior intact.

### What’s included
  - Added Codex scripts:
    - `scripts/codex-with-notify`
    - `scripts/codex-watch`
    - `scripts/codex-notify`
  - Added optional user service:
    - `systemd/user/codex-watch.service`
  - Added Codex installation guide:
    - `docs/codex-installation.md`
  - Updated README with Codex section and link to the installation guide.

### Behavior

  - `codex-with-notify` runs Codex and starts/stops `codex-watch` automatically.
  - `codex-watch` monitors Codex session events and triggers notifications on `task_complete`.
  - `codex-notify` sends dunst notifications and supports click-to-jump back to tmux pane/window when available.

